### PR TITLE
TG-946 Add `truthy-bool` rule to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ omit = [
 source = ["."]
 
 [tool.mypy]
+enable_error_code = [
+     "truthy-bool",
+ ]
 python_version = "3.11"
 ignore_missing_imports = true
 


### PR DESCRIPTION
Adds the pyproject rule implementing the following concept:

> Sometimes code uses boolean checks on variables that can only be true. This is normally a sign of a mistake, either in the type hints or the implementation. Mypy has an optional check that can find such problematic boolean usage with its [truthy-bool error code](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-expression-is-not-implicitly-true-in-boolean-context-truthy-bool).

https://adamj.eu/tech/2022/10/24/python-type-hints-truthy-bool/