### PR TITLE
Rewrite TFC module for service workspaces under tfe_project

### DIFF
--- a/bootstrap/runner.py
+++ b/bootstrap/runner.py
@@ -60,6 +60,7 @@ class Runner:
     terraform_cloud_token: str | None = None
     terraform_cloud_organization: str | None = None
     terraform_cloud_organization_create: bool | None = None
+    terraform_cloud_project_create: bool = True
     terraform_cloud_admin_email: str | None = None
     vault_token: str | None = None
     vault_url: str | None = None
@@ -253,7 +254,10 @@ class Runner:
             "TF_VAR_create_organization": self.terraform_cloud_organization_create
             and "true"
             or "false",
-            "TF_VAR_environments": json.dumps(list(map(itemgetter("slug"), self.envs))),
+            "TF_VAR_create_project": self.terraform_cloud_project_create
+            and "true"
+            or "false",
+            "TF_VAR_environments": json.dumps(list(map(itemgetter("name"), self.envs))),
             "TF_VAR_hostname": self.terraform_cloud_hostname,
             "TF_VAR_organization_name": self.terraform_cloud_organization,
             "TF_VAR_project_name": self.project_name,

--- a/terraform/terraform-cloud/main.tf
+++ b/terraform/terraform-cloud/main.tf
@@ -1,39 +1,19 @@
 locals {
   organization = var.create_organization ? tfe_organization.main[0] : data.tfe_organization.main[0]
+  project      = var.create_project ? tfe_project.main[0] : data.tfe_project.main[0]
 
-  workspaces = concat(
-    flatten(
-      [
-        for stage in ["base", "cluster"] :
-        [
-          for stack in var.stacks :
-          {
-            name        = "${var.project_slug}_${var.service_slug}_${stage}_${stack}"
-            description = "${var.project_name} project, ${var.service_slug} service, ${stack} stack, ${stage} stage"
-            tags = [
-              "project:${var.project_slug}",
-              "service:${var.service_slug}",
-              "stage:${stage}",
-              "stack:${stack}",
-            ]
-          }
-        ]
+  workspaces = [
+    for env in var.environments : {
+      name        = "${var.project_slug}_${var.service_slug}_${env}"
+      description = "${var.project_name} ${var.service_slug} service, ${env} environment."
+      tags = [
+        "project:${var.project_slug}",
+        "layer:service",
+        "service:${var.service_slug}",
+        "environment:${env}",
       ]
-    ),
-    [
-      for env in var.environments :
-      {
-        name        = "${var.project_slug}_${var.service_slug}_environment_${env}"
-        description = "${var.project_name} project, ${var.service_slug} service, ${env} environment"
-        tags = [
-          "project:${var.project_slug}",
-          "service:${var.service_slug}",
-          "stage:environment",
-          "env:${env}",
-        ]
-      }
-    ]
-  )
+    }
+  ]
 }
 
 terraform {
@@ -43,7 +23,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.53"
+      version = "~> 0.70"
     }
   }
 }
@@ -68,20 +48,32 @@ resource "tfe_organization" "main" {
   email = var.admin_email
 }
 
+/* Project */
+
+data "tfe_project" "main" {
+  count = var.create_project ? 0 : 1
+
+  name         = var.project_slug
+  organization = local.organization.name
+}
+
+resource "tfe_project" "main" {
+  count = var.create_project ? 1 : 0
+
+  organization           = local.organization.name
+  name                   = var.project_slug
+  description            = "${var.project_name} project workspaces."
+  default_execution_mode = "local"
+}
+
 /* Workspaces */
 
 resource "tfe_workspace" "main" {
   for_each = { for i in local.workspaces : i.name => i }
 
-  name           = each.value.name
-  description    = each.value.description
-  organization   = local.organization.name
-  tag_names      = each.value.tags
-}
-
-resource "tfe_workspace_settings" "main" {
-  for_each = tfe_workspace.main
-
-  workspace_id   = each.value.id
-  execution_mode = "local"
+  name         = each.value.name
+  description  = each.value.description
+  organization = local.organization.name
+  project_id   = local.project.id
+  tag_names    = each.value.tags
 }

--- a/terraform/terraform-cloud/variables.tf
+++ b/terraform/terraform-cloud/variables.tf
@@ -10,8 +10,14 @@ variable "create_organization" {
   default     = false
 }
 
+variable "create_project" {
+  description = "Tell if the Terraform Cloud project should be created (false when Talos parent has already created it)."
+  type        = bool
+  default     = true
+}
+
 variable "environments" {
-  description = "The list of environment slugs."
+  description = "The list of environment names (used as workspace suffix)."
   type        = list(string)
   default     = []
 }
@@ -40,12 +46,6 @@ variable "project_slug" {
 variable "service_slug" {
   description = "The service slug."
   type        = string
-}
-
-variable "stacks" {
-  description = "The list of stack slugs."
-  type        = list(string)
-  default     = []
 }
 
 variable "terraform_cloud_token" {


### PR DESCRIPTION
## Summary

Follow-up to #84. Aligns the generated TFC module with the canonical Minos workspace layout (piano TG-1175 §6, §7).

## Changes

- **TFC project**: introduce `tfe_project.main` with `default_execution_mode = "local"`. All service workspaces live under it via `project_id`.
- **Workspace naming**: `${project_slug}_${service_slug}_${env_name}` (e.g. `gs1-one_frontend_development`). Drop the legacy `base`/`cluster` workspaces per stack.
- **Drop `tfe_workspace_settings`**: execution mode is now inherited from the project, no per-workspace override needed.
- **`create_project` flag** (default `true`): when Talos has already created the project, the module reads it as a `data` source instead.
- **TFE provider**: bump `~> 0.53` → `~> 0.70`.
- **Runner**: new field `terraform_cloud_project_create: bool = True`; passes `TF_VAR_create_project`; switches `TF_VAR_environments` payload from env slugs to env names (matches workspace naming).
- **`stacks` variable removed** from `terraform-cloud/variables.tf`.

## Notes

- Existing TFC organizations created by #84 will need their pre-existing per-stack workspaces removed by hand — this PR no longer manages them.
- Pairs with the same convention being adopted in `talos` and `django-continuous-delivery`.
